### PR TITLE
StandardError -> Exception

### DIFF
--- a/djangocms_link/cms_plugins.py
+++ b/djangocms_link/cms_plugins.py
@@ -63,5 +63,5 @@ plugin_pool.register_plugin(ButtonPlugin)
 try:
     from aldryn_bootstrap3.cms_plugins import Bootstrap3ButtonCMSPlugin
     plugin_pool.unregister_plugin(Bootstrap3ButtonCMSPlugin)
-except StandardError:
+except Exception:
     pass


### PR DESCRIPTION
This is for compatibility with Python 3. StandardError is eliminated there, and makes the plugin impossible to install. 

This small change makes it compatible with Python 3, and should make no difference for Python 2.7